### PR TITLE
Multiple Flag fixes, fixing sphere breaking and important item remova…

### DIFF
--- a/Generator/Assets/Flags.cs
+++ b/Generator/Assets/Flags.cs
@@ -65,7 +65,10 @@ namespace TPRandomizer.Assets
             { 0x17, 0x94 }, // Set flag to trigger the twilight fence before Zant
             { 0x3, 0x42 }, // Big Rock fell at DMT
             { 0x6, 0x83 }, // Set the flag for the Ganon Barriers in Hyrule Field during Eldin Twilight.
-            { 0x9, 0x1F }, // Original Jovani Poe killed. It is replaced with a custom actor.
+            { 0x9, 0x40 }, // Original Jovani Poe killed. It is replaced with a custom actor.
+            { 0x9, 0x76 }, // Jovani Chest CS 2
+            { 0x9, 0x7F }, // Open Chest to Jovani
+            { 0x9, 0x7E }, // Jovani Chest CS
         };
 
         /// <summary>
@@ -408,6 +411,7 @@ namespace TPRandomizer.Assets
             { 0xF7, 0x1 }, // Add 256 Rupees to Charlo.
             { 0xF8, 0xF4 }, // Add 244 Rupees to Charlo.
             { 0x60, 0x1 }, // Talked to Fyer after Lanayru Twilight
+            { 0x38, 0x80 }, // Talked to Jovani after defeating Poe.
         };
 
         /// <summary>

--- a/Generator/Logic/BackendFunctions.cs
+++ b/Generator/Logic/BackendFunctions.cs
@@ -420,6 +420,7 @@ namespace TPRandomizer
 
             bool playthroughStatus;
             Item currentItem;
+
             foreach (KeyValuePair<string, Check> dictEntry in playthroughDictionary.Reverse())
             {
                 if (dictEntry.Value != null)
@@ -430,6 +431,8 @@ namespace TPRandomizer
                     if (playthroughStatus)
                     {
                         playthroughDictionary.Remove(dictEntry.Key);
+                        Randomizer.Checks.CheckDict[dictEntry.Value.checkName].itemWasPlaced =
+                            false;
                     }
                     Randomizer.Checks.CheckDict[dictEntry.Value.checkName].itemId = currentItem;
                 }
@@ -544,7 +547,7 @@ namespace TPRandomizer
                                 }
                             }
 
-                            if (!currentCheck.hasBeenReached)
+                            if (!currentCheck.hasBeenReached && currentCheck.itemWasPlaced)
                             {
                                 var areCheckRequirementsMet = Randomizer.Logic.EvaluateRequirements(
                                     currentCheck.requirements

--- a/Generator/World/Checks/Overworld/Faron Province/Faron Woods Golden Wolf.json
+++ b/Generator/World/Checks/Overworld/Faron Province/Faron Woods Golden Wolf.json
@@ -5,8 +5,8 @@
     "replacementType": [1,1,1,1,1,1,1],
     "stageIDX": [64,64,64,64,64,64,64],
     "lastStageIDX": [45],
-    "roomIDX": 1,
+    "roomIDX": 6,
     "flag": "3D6",
-    "category": ["Overworld", "Hidden Skill", "Faron Province", "ARC"],
+    "category": ["Overworld", "Hidden Skill", "Faron Woods", "ARC"],
     "itemId": "Progressive_Hidden_Skill"
 }


### PR DESCRIPTION
…l. (#13)

* Fixed generator removing important items from pool and defaulting non important checks

* Fixed starting items error and accounted for the possibility of keys being in their own region for the "Any Dungeon" Setting

* Added backend code to support vanilla agitha if npcs are not shuffled

* Fixed golden wolf text not working and Jovani Poe flag

* Fixed some jovani poe flags

* Add secondary flag for Jovani chest CS

* Fix optimal playthrough breaking spheres